### PR TITLE
Add simple route for /

### DIFF
--- a/dcos_openvpn/web.py
+++ b/dcos_openvpn/web.py
@@ -17,6 +17,10 @@ from . import scheduler
 
 app = Flask(__name__)
 
+@app.route("/")
+def root():
+    return "OpenVPN running, to add users see: https://github.com/mesosphere/dcos-openvpn"
+
 @app.route("/status")
 def status():
     return "ok"


### PR DESCRIPTION
The DCOS UI shows openvpn nicely in the service view but following the
link leads to a 404 because dcos_openvpn has no route for /.
