### PR TITLE
Read framework name from FRAMEWORK_NAME env var

### DIFF
--- a/dcos_openvpn/scheduler.py
+++ b/dcos_openvpn/scheduler.py
@@ -18,7 +18,7 @@ from . import util
 
 class VPNScheduler(Scheduler):
 
-    name = "openvpn"
+    name = os.environ.get("FRAMEWORK_NAME", "openvpn")
     image = os.environ.get("IMAGE", "mesosphere/dcos-openvpn")
 
     role = "slave_public"


### PR DESCRIPTION
This is necessary because for multi/universe packages it's required that the framework name can be customized.
