### PR TITLE
Upstream changed: Use apk to install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,9 @@ ENV MESOS_EGG mesos-0.24.1-py2.7-linux-x86_64.egg
 
 MAINTAINER Mesosphere <team@mesosphere.com>
 
-RUN apt-get update && \
-    apt-get install -y curl wget libsvn1 python2.7-minimal python-setuptools && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN wget http://downloads.mesosphere.io/master/ubuntu/15.04/$MESOS_EGG \
-    && easy_install $MESOS_EGG && rm $MESOS_EGG
+RUN apk -U add python py-setuptools && apk -U -t deps add curl ca-certificates \
+    && curl -Lo $MESOS_EGG https://downloads.mesosphere.io/master/ubuntu/15.04/$MESOS_EGG \
+    && easy_install-2.7 $MESOS_EGG && rm $MESOS_EGG && apk del deps
 
 COPY . /dcos
 


### PR DESCRIPTION
Upstream changed to alpine linux, so we need to use apk to install
packages.
