### PR TITLE
Fix abandoned get_location method

### DIFF
--- a/bin/run.bash
+++ b/bin/run.bash
@@ -41,10 +41,6 @@ do
   esac
 done
 
-function get_location {
-  echo $(run_command "get $ZKPATH/location.conf")
-}
-
 function run_command {
   $ZKCLI --run-once "$1" $ZKURL 2>&1
   return $?

--- a/dcos_openvpn/cert.py
+++ b/dcos_openvpn/cert.py
@@ -22,7 +22,7 @@ def upload(name):
                 os.environ.get("CONFIG_LOCATION"))), shell=True)
 
 def output(name):
-    loc = subprocess.check_output("/dcos/bin/run.bash get_location", shell=True)
+    loc = subprocess.check_output('$ZKCLI --run-once "get $ZKPATH/location.conf" $ZKURL', shell=True)
     return re.sub("remote .*", loc, subprocess.check_output(
         "ovpn_getclient {0}".format(name), shell=True))
 


### PR DESCRIPTION
I guess that run.bash its supposed to run only server|admin arguments to mantain consistency
