### PR TITLE
Allowed external use of get_location on run.bash

### DIFF
--- a/bin/run.bash
+++ b/bin/run.bash
@@ -125,5 +125,6 @@ function out { printf '%s\n' "$*" ;}
 case "$@" in
   server) server ;;
   admin)  admin  ;;
+  get_location) get_location ;;
   *)      usage;  exit 1 ;;
 esac


### PR DESCRIPTION
fixes #16 
